### PR TITLE
Added config/.env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode/*
+config/.env


### PR DESCRIPTION
I've been using my own mongoDB account in my development environment.
config/.env should still be provided but in case it isn't  
```
DB_STRING = your mongo URI
PORT = 2121
````
inside of `config/.env` should work without any problems